### PR TITLE
Auto-Capture Mode

### DIFF
--- a/Classes/MobileOrgAppDelegate.m
+++ b/Classes/MobileOrgAppDelegate.m
@@ -34,6 +34,7 @@ __asm__(".weak_reference _OBJC_CLASS_$_NSURL");
 #import "DataUtils.h"
 #import "Reachability.h"
 #import "SessionManager.h"
+#import "Settings.h"
 
 @interface MobileOrgAppDelegate(private)
 - (void)updateInterfaceWithReachability:(Reachability*)curReach;
@@ -77,6 +78,17 @@ __asm__(".weak_reference _OBJC_CLASS_$_NSURL");
     [[SessionManager instance] restore];
 
     [window makeKeyAndVisible];
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    if ([[Settings instance] launchTab] == LaunchTabCapture) {
+            // TODO Add some sort of minimum time-lapse to activate
+            // that is, don't create a new capture if the button was hit accidentally
+            // (Allow maybe a minute or two before this setting 'sctivates' again)
+            // (this can be done by storing the time and doing a difference.)
+        [[self tabBarController] setSelectedIndex:1]; // Capture!!
+        [[self noteListController] addNote];
+    }
 }
 
 /**

--- a/Classes/Settings/Settings.h
+++ b/Classes/Settings/Settings.h
@@ -34,6 +34,11 @@ typedef enum {
     ServerModeDropbox
 } ServerMode;
 
+typedef enum {
+    LaunchTabOutline = 0,
+    LaunchTabCapture,
+} LaunchTab;
+
 @interface Settings : NSObject {
     NSURL *indexUrl;
 
@@ -51,6 +56,8 @@ typedef enum {
     AppBadgeMode appBadgeMode;
 
     ServerMode serverMode;
+    
+    LaunchTab launchTab;
 
     NSString *dropboxIndex;
     
@@ -68,6 +75,7 @@ typedef enum {
 @property (nonatomic, copy) NSMutableArray *priorities;
 @property (nonatomic) AppBadgeMode appBadgeMode;
 @property (nonatomic) ServerMode serverMode;
+@property (nonatomic) LaunchTab launchTab;
 @property (nonatomic, copy) NSString *dropboxIndex;
 @property (nonatomic, copy) NSString *encryptionPassword;
 

--- a/Classes/Settings/Settings.m
+++ b/Classes/Settings/Settings.m
@@ -46,6 +46,7 @@ static NSString *kTodoStateGroupsKey = @"TodoStateGroups";
 static NSString *kPrioritiesKey      = @"Priorities";
 static NSString *kAppBadgeModeKey    = @"AppBadgeMode";
 static NSString *kServerModeKey      = @"ServerMode";
+static NSString *kLaunchTabKey       = @"LaunchTab";
 static NSString *kDropboxIndexKey    = @"DropboxIndex";
 static NSString *kEncryptionPassKey  = @"EncryptionPassword";
 
@@ -62,6 +63,7 @@ static NSString *kEncryptionPassKey  = @"EncryptionPassword";
 @synthesize priorities;
 @synthesize appBadgeMode;
 @synthesize serverMode;
+@synthesize launchTab;
 @synthesize dropboxIndex;
 @synthesize encryptionPassword;
 
@@ -130,6 +132,11 @@ static NSString *kEncryptionPassKey  = @"EncryptionPassword";
         serverMode = [[NSUserDefaults standardUserDefaults] integerForKey:kServerModeKey];
         if (!serverMode) {
             self.serverMode = ServerModeWebDav;
+        }
+        
+        launchTab = [[NSUserDefaults standardUserDefaults] integerForKey:kLaunchTabKey];
+        if (!serverMode) {
+            self.launchTab = LaunchTabOutline;
         }
 
         dropboxIndex = [[NSUserDefaults standardUserDefaults] objectForKey:kDropboxIndexKey];
@@ -306,6 +313,12 @@ static NSString *kEncryptionPassKey  = @"EncryptionPassword";
 - (void)setServerMode:(ServerMode)newServerMode {
     serverMode = newServerMode;
     [[NSUserDefaults standardUserDefaults] setInteger:serverMode forKey:kServerModeKey];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
+- (void)setLaunchTab:(LaunchTab)newLaunchTab {
+    launchTab = newLaunchTab;
+    [[NSUserDefaults standardUserDefaults] setInteger:launchTab forKey:kLaunchTabKey];
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 

--- a/Classes/Settings/SettingsController.m
+++ b/Classes/Settings/SettingsController.m
@@ -134,7 +134,7 @@ enum {
             return 2;
             break;
         case SettingsGroup:
-            return 1;
+            return 2;
             break;
         case EncryptionGroup:
             return 1;
@@ -393,6 +393,31 @@ enum {
 
                 return cell;
             }
+            case 1:
+            {
+                static NSString *CellIdentifier = @"SettingsLaunchTabCell";
+                
+                UISwitch *launchTabSwitch = nil;
+                UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
+                if (cell == nil) {
+                    cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier] autorelease];
+                    if (IsIpad())
+                        launchTabSwitch = [[[UISwitch alloc] initWithFrame:CGRectMake(620,10,200,25)] autorelease];
+                    else
+                        launchTabSwitch = [[[UISwitch alloc] initWithFrame:CGRectMake(200,10,200,25)] autorelease];
+                    [cell addSubview:launchTabSwitch];
+                    [cell setSelectionStyle:UITableViewCellSelectionStyleNone];
+                    [[cell textLabel] setFont:[UIFont boldSystemFontOfSize:15.0]];
+                } else {
+                    launchTabSwitch = (UISwitch*)[cell.contentView viewWithTag:1];
+                }
+                
+                [launchTabSwitch addTarget:self action:@selector(launchTabSwitchChanged:) forControlEvents:UIControlEventValueChanged];
+                [[cell textLabel] setText:@"AutoCapture Mode"];
+                [launchTabSwitch setOn:([[Settings instance] launchTab] == LaunchTabCapture)];
+                
+                return cell;
+            }
             default:
                 break;
         }
@@ -602,6 +627,15 @@ enum {
     }
     [[self tableView] reloadData];
     [[self tableView] setNeedsDisplay];
+}
+
+- (void)launchTabSwitchChanged:(id)sender {
+    UISwitch *launchTabSwitch = (UISwitch*)sender;
+    if ([launchTabSwitch isOn]) {
+        [[Settings instance] setLaunchTab:LaunchTabCapture];
+    } else {
+        [[Settings instance] setLaunchTab:LaunchTabOutline];
+    }
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {


### PR DESCRIPTION
Added Autocapture Mode that does exactly what was asked for in issue/request #14 -- but more polishing could be done
- minimum time elapse for a new note to be created rather than just going back to where you were (the 'oops, I nicked the home button' scenario)
- true cancel functionality in the `newNoteController` (it could get a little annoying to keep having to delete such an auto-created note and have the sync count keep incrementing)

![(screen shot)](https://f.cloud.github.com/assets/2082195/162083/96447e64-77aa-11e2-901f-daf3c16086e5.png)
