### PR TITLE
Enable to show the dropbox sign in page on iOS9 beta.

### DIFF
--- a/MobileOrg-Info.plist
+++ b/MobileOrg-Info.plist
@@ -59,6 +59,10 @@
 	<string>MainWindow</string>
 	<key>UIPrerenderedIcon</key>
 	<true/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>db-${APP_KEY}</string>
+	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
Add LSApplicationQueriesSchemes to Info.plist.
See also, WWDC 2015 session 703 "Privacy and Your Apps", Slide 22 of the PDF.
