### PR TITLE
Removed more warnings

### DIFF
--- a/Classes/Capture/NewNoteController.m
+++ b/Classes/Capture/NewNoteController.m
@@ -146,7 +146,7 @@
     NSDictionary* info = [aNotification userInfo];
 
     // Get the size of the keyboard.
-    NSValue* aValue = [info objectForKey:UIKeyboardBoundsUserInfoKey];
+    NSValue* aValue = [info objectForKey:UIKeyboardFrameBeginUserInfoKey];
     CGSize keyboardSize = [aValue CGRectValue].size;
 
     // Reset the height of the scroll view to its original value

--- a/Classes/Outline/ActionMenuController.m
+++ b/Classes/Outline/ActionMenuController.m
@@ -130,7 +130,7 @@
                 leftButtonX = 100;
             rightButtonX = leftButtonX + 150;            
             yOffset = 10;
-            actionView.frame = [[UIScreen mainScreen] applicationFrame];
+            actionView.frame = [[UIScreen mainScreen] bounds];
             break;
 
         case UIDeviceOrientationPortrait:
@@ -142,7 +142,7 @@
                 leftButtonX = 20;
             rightButtonX = leftButtonX + 150;            
             yOffset = 40;
-            actionView.frame = [[UIScreen mainScreen] applicationFrame];
+            actionView.frame = [[UIScreen mainScreen] bounds];
             break;
     }
 
@@ -287,7 +287,7 @@
     return YES;
 }
 
-- (NSUInteger)supportedInterfaceOrientations {
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskAll;
 }
 

--- a/Classes/Outline/DetailsViewController.m
+++ b/Classes/Outline/DetailsViewController.m
@@ -154,7 +154,7 @@ typedef enum {
         NSIndexPath *path = [c pathForNode:node];
         if (path) {
             [[self navigationController] popViewControllerAnimated:NO];
-            [[SessionManager instance] popOutlineStateToLevel:[self.navigationController.viewControllers indexOfObject:self]-1];
+            [[SessionManager instance] popOutlineStateToLevel:(int)[self.navigationController.viewControllers indexOfObject:self]-1];
             [c selectRowAtIndexPath:path withType:OutlineSelectionTypeExpandOutline andAnimation:YES];
         }
     }
@@ -224,6 +224,8 @@ typedef enum {
                 [controller release];
                 break;
             }
+            default:
+            break;
         }
     }
 }
@@ -255,7 +257,7 @@ typedef enum {
     [super viewWillAppear:animated];
     [self refreshData];
 
-    [[SessionManager instance] popOutlineStateToLevel:[self.navigationController.viewControllers indexOfObject:self]];
+    [[SessionManager instance] popOutlineStateToLevel:(int)[self.navigationController.viewControllers indexOfObject:self]];
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {

--- a/Classes/Outline/DocumentViewController.m
+++ b/Classes/Outline/DocumentViewController.m
@@ -57,6 +57,8 @@ __asm__(".weak_reference _OBJC_CLASS_$_NSURL");
                 [controller release];
                 break;
             }
+            default:
+            break;
         }
     }
 }
@@ -159,7 +161,7 @@ __asm__(".weak_reference _OBJC_CLASS_$_NSURL");
     [super viewWillAppear:animated];
 
     // Get rid of anything else in the stored tree that has level > ours
-    [[SessionManager instance] popOutlineStateToLevel:[self.navigationController.viewControllers indexOfObject:self]];
+    [[SessionManager instance] popOutlineStateToLevel:(int)[self.navigationController.viewControllers indexOfObject:self]];
 
     timer = [[NSTimer scheduledTimerWithTimeInterval: 1.0
                                               target: self

--- a/Classes/Outline/NodeTextEditController.m
+++ b/Classes/Outline/NodeTextEditController.m
@@ -97,7 +97,7 @@
     NSDictionary* info = [aNotification userInfo];
 
     // Get the size of the keyboard.
-    NSValue* aValue = [info objectForKey:UIKeyboardBoundsUserInfoKey];
+    NSValue* aValue = [info objectForKey:UIKeyboardFrameBeginUserInfoKey];
     CGSize keyboardSize = [aValue CGRectValue].size;
 
     // Reset the height of the scroll view to its original value
@@ -130,7 +130,7 @@
     [textView setDelegate:self];
     [self setView:textView];
 
-    bool created;
+    bool created = false;
 
     // TODO: make the setText calls use this instead
     // [self unindentText:[node heading]] etc
@@ -175,15 +175,15 @@
     for (NSString *line in lines) {
         NSArray *captures = [line captureComponentsMatchedByRegex:@"( +).+"];
         if ([captures count] > 0) {
-            int spaces = [[captures objectAtIndex:0] length];
+            int spaces = (int)[[captures objectAtIndex:0] length];
             if (spaces < indentLevel)
                 indentLevel = spaces;
         }
     }
 
-    for (NSString *line in lines) {
-        // TODO: Do the unindention
-    }
+    // TODO: Do the unindention
+    //    for (NSString *line in lines) {
+    //    }
 
     return nil;
 }

--- a/Classes/Outline/OutlineViewController.m
+++ b/Classes/Outline/OutlineViewController.m
@@ -402,7 +402,7 @@
     }
 
     // Save our state by getting rid of anything above us in the session
-    [[SessionManager instance] popOutlineStateToLevel:[self.navigationController.viewControllers indexOfObject:self]];
+    [[SessionManager instance] popOutlineStateToLevel:(int)[self.navigationController.viewControllers indexOfObject:self]];
 
     // TODO: For now, just always refresh when we're going to display
     // Perhaps this isn't the best thing, it'd be nice if we didn't call

--- a/Classes/Parsing/EditsFileParser.m
+++ b/Classes/Parsing/EditsFileParser.m
@@ -105,7 +105,7 @@
                 if ([editEntities count] > 0) {
                     EditEntity *lastEntity = [editEntities lastObject];
                     int lastNonspaceChar;
-                    for (lastNonspaceChar = [lastEntity.newValue length]-1; lastNonspaceChar >= 0; lastNonspaceChar--) {
+                    for (lastNonspaceChar = (int)[lastEntity.newValue length]-1; lastNonspaceChar >= 0; lastNonspaceChar--) {
                         char c = [lastEntity.newValue characterAtIndex:lastNonspaceChar];
                         if (c != '\n' && c != '\r' && c != ' ' && c != '\t' && c != 0) {
                             break;
@@ -142,7 +142,7 @@
                 if ([editEntities count] > 0) {
                     EditEntity *lastEntity = [editEntities lastObject];
                     int lastNonspaceChar;
-                    for (lastNonspaceChar = [lastEntity.newValue length]-1; lastNonspaceChar >= 0; lastNonspaceChar--) {
+                    for (lastNonspaceChar = (int)[lastEntity.newValue length]-1; lastNonspaceChar >= 0; lastNonspaceChar--) {
                         char c = [lastEntity.newValue characterAtIndex:lastNonspaceChar];
                         if (c != '\n' && c != '\r' && c != ' ' && c != '\t' && c != 0) {
                             break;
@@ -244,7 +244,7 @@
     if ([editEntities count] > 0) {
         EditEntity *lastEntity = [editEntities lastObject];
         int lastNonspaceChar;
-        for (lastNonspaceChar = [lastEntity.newValue length]-1; lastNonspaceChar >= 0; lastNonspaceChar--) {
+        for (lastNonspaceChar = (int)[lastEntity.newValue length]-1; lastNonspaceChar >= 0; lastNonspaceChar--) {
             char c = [lastEntity.newValue characterAtIndex:lastNonspaceChar];
             if (c != '\n' && c != '\r' && c != ' ' && c != '\t' && c != 0) {
                 break;

--- a/Classes/Search/SearchController.m
+++ b/Classes/Search/SearchController.m
@@ -42,7 +42,7 @@
 }
 
 - (NSIndexPath*)pathForNode:(Node*)node {
-    int index = [[self nodesArray] indexOfObject:node];
+    int index = (int)[[self nodesArray] indexOfObject:node];
     if (index >= 0 && index < [nodesArray count]) {
         return [NSIndexPath indexPathForRow:index inSection:0];
     }
@@ -85,10 +85,8 @@
             ret = controller;
             break;
         }
-        case OutlineSelectionTypeDocumentView:
-        {
+      default:
             break;
-        }
     }
 
     return ret;
@@ -261,7 +259,7 @@
     }
 
     NSString *context_str = @"";
-    for (int i = [context count]-1; i >= 0; i--) {
+    for (int i = (int)[context count]-1; i >= 0; i--) {
         if ([context_str length] > 0) {
             context_str = [NSString stringWithFormat:@"%@ > %@", context_str, [[context objectAtIndex:i] headingForDisplay]];
         } else {

--- a/Classes/Settings/SessionManager.m
+++ b/Classes/Settings/SessionManager.m
@@ -89,7 +89,7 @@ static NSString *kWhichTabKey      = @"WhichTab";
 }
 
 - (void)storeCurrentTab {
-    int whichTab = [[AppInstance() tabBarController] selectedIndex];
+    int whichTab = (int)[[AppInstance() tabBarController] selectedIndex];
     [[NSUserDefaults standardUserDefaults] setObject:[NSNumber numberWithInt:whichTab] forKey:kWhichTabKey];
     [[NSUserDefaults standardUserDefaults] synchronize];
 }

--- a/Classes/Settings/Settings.m
+++ b/Classes/Settings/Settings.m
@@ -124,17 +124,17 @@ static NSString *kEncryptionPassKey  = @"EncryptionPassword";
             self.priorities = [NSMutableArray arrayWithCapacity:0];
         }
 
-        appBadgeMode = [[NSUserDefaults standardUserDefaults] integerForKey:kAppBadgeModeKey];
+        appBadgeMode = (AppBadgeMode)[[NSUserDefaults standardUserDefaults] integerForKey:kAppBadgeModeKey];
         if (!appBadgeMode) {
             self.appBadgeMode = AppBadgeModeNone;
         }
 
-        serverMode = [[NSUserDefaults standardUserDefaults] integerForKey:kServerModeKey];
+        serverMode = (ServerMode)[[NSUserDefaults standardUserDefaults] integerForKey:kServerModeKey];
         if (!serverMode) {
             self.serverMode = ServerModeWebDav;
         }
         
-        launchTab = [[NSUserDefaults standardUserDefaults] integerForKey:kLaunchTabKey];
+        launchTab = (LaunchTab)[[NSUserDefaults standardUserDefaults] integerForKey:kLaunchTabKey];
         if (!serverMode) {
             self.launchTab = LaunchTabOutline;
         }

--- a/Classes/Settings/SettingsController.m
+++ b/Classes/Settings/SettingsController.m
@@ -643,7 +643,7 @@ enum {
 - (void)modeSwitchChanged:(id)sender {
     UISegmentedControl *modeSwitch = (UISegmentedControl*)sender;
     if ([[Settings instance] serverMode] != (1 + [modeSwitch selectedSegmentIndex])) {
-        [[Settings instance] setServerMode:(1 + [modeSwitch selectedSegmentIndex])];
+        [[Settings instance] setServerMode:(ServerMode)(1 + [modeSwitch selectedSegmentIndex])];
         [self resetAppData];
     }
     [[self tableView] reloadData];

--- a/Classes/Status/StatusViewController.m
+++ b/Classes/Status/StatusViewController.m
@@ -60,23 +60,23 @@ static StatusViewController *gInstance = NULL;
             return;
         case UIDeviceOrientationPortraitUpsideDown:
             [self.view setTransform:CGAffineTransformMakeRotation(M_PI)];
-            [self.view setFrame:[[UIScreen mainScreen] applicationFrame]];
+            [self.view setFrame:[[UIScreen mainScreen] bounds]];
             statusView.center = CGPointMake(self.view.frame.size.width/2, self.view.frame.size.height/2);
             break;
         case UIDeviceOrientationLandscapeLeft:
             [self.view setTransform:CGAffineTransformMakeRotation(M_PI/2)];
-            [self.view setFrame:[[UIScreen mainScreen] applicationFrame]];
+            [self.view setFrame:[[UIScreen mainScreen] bounds]];
             statusView.center = CGPointMake(self.view.frame.size.height/2, self.view.frame.size.width/2+20);
             break;
         case UIDeviceOrientationLandscapeRight:
             [self.view setTransform:CGAffineTransformMakeRotation(-M_PI/2)];
-            [self.view setFrame:[[UIScreen mainScreen] applicationFrame]];
+            [self.view setFrame:[[UIScreen mainScreen] bounds]];
             statusView.center = CGPointMake(self.view.frame.size.height/2, self.view.frame.size.width/2+20);
             break;
         case UIDeviceOrientationPortrait:
         default:
             [self.view setTransform:CGAffineTransformMakeRotation(0)];
-            [self.view setFrame:[[UIScreen mainScreen] applicationFrame]];
+            [self.view setFrame:[[UIScreen mainScreen] bounds]];
             statusView.center = CGPointMake(self.view.frame.size.width/2, self.view.frame.size.height/2);
             break;
     }

--- a/Classes/Sync/SyncManager.m
+++ b/Classes/Sync/SyncManager.m
@@ -95,7 +95,7 @@ static SyncManager *gInstance = NULL;
     if ([[Settings instance] serverMode] == ServerModeWebDav) {
         return [WebDavTransferManager instance];
     } else if ([[Settings instance] serverMode] == ServerModeDropbox) {
-        return [DropboxTransferManager instance];
+        return (TransferManager *)[DropboxTransferManager instance];
     }
     return nil;
 }

--- a/Classes/Sync/WebDav/WebDavTransferManager.m
+++ b/Classes/Sync/WebDav/WebDavTransferManager.m
@@ -33,6 +33,13 @@ __asm__(".weak_reference _OBJC_CLASS_$_NSURL");
 #import "Settings.h"
 
 @implementation NSURLRequest(NSHTTPURLRequest)
+@dynamic HTTPBody;
+@dynamic HTTPShouldHandleCookies;
+@dynamic HTTPMethod;
+@dynamic HTTPBodyStream;
+@dynamic HTTPShouldUsePipelining;
+@dynamic allHTTPHeaderFields;
+
 + (BOOL)allowsAnyHTTPSCertificateForHost:(NSString *)host
 {
     return YES; // Or whatever logic
@@ -228,7 +235,7 @@ static WebDavTransferManager *gInstance = NULL;
 
 - (void)connection:(NSURLConnection*)connection didReceiveResponse:(NSURLResponse*)response {
 
-    activeTransfer.statusCode = [ (NSHTTPURLResponse*)response statusCode];
+    activeTransfer.statusCode = (int)[ (NSHTTPURLResponse*)response statusCode];
     if (activeTransfer.statusCode >= 400 && activeTransfer.statusCode < 600) {
         activeTransfer.success = false;
     } else if (activeTransfer.statusCode == 302) {
@@ -247,7 +254,7 @@ static WebDavTransferManager *gInstance = NULL;
 
     SyncManager *mgr = [SyncManager instance];
     [mgr setProgressTotal:[self.fileSize intValue]];
-    [mgr setProgressCurrent:[data length]];
+    [mgr setProgressCurrent:(int)[data length]];
     [mgr updateStatus];
 }
 
@@ -312,7 +319,7 @@ static WebDavTransferManager *gInstance = NULL;
 }
 
 - (int)queueSize {
-    return [transfers count];
+    return (int)[transfers count];
 }
 
 - (void)abort {

--- a/Classes/Utilities/DataUtils.m
+++ b/Classes/Utilities/DataUtils.m
@@ -474,7 +474,7 @@ int CountLocalEditActions() {
     [request setPredicate:predicate];
 
     NSError *error = nil;
-    NSUInteger count = [managedObjectContext countForFetchRequest:request error:&error];
+    int count = (int)[managedObjectContext countForFetchRequest:request error:&error];
 
     [request release];
 
@@ -629,7 +629,7 @@ int CountNotes() {
     [request setEntity: [NSEntityDescription entityForName:@"Note" inManagedObjectContext:managedObjectContext]];
 
     NSError *error = nil;
-    NSUInteger count = [managedObjectContext countForFetchRequest:request error:&error];
+    int count = (int)[managedObjectContext countForFetchRequest:request error:&error];
 
     [request release];
 
@@ -647,7 +647,7 @@ int CountLocalNotes() {
     [request setPredicate:predicate];
 
     NSError *error = nil;
-    NSUInteger count = [managedObjectContext countForFetchRequest:request error:&error];
+    int count = (int)[managedObjectContext countForFetchRequest:request error:&error];
 
     [request release];
 

--- a/Classes/Utilities/GlobalUtils.m
+++ b/Classes/Utilities/GlobalUtils.m
@@ -131,7 +131,7 @@ NSString *ReadPossiblyEncryptedFile(NSString *filename, NSString **error) {
 // From: http://stackoverflow.com/questions/652300/using-md5-hash-on-a-string-in-cocoa
 NSString *md5(unsigned char *bytes, size_t len) {
     unsigned char result[16];
-    CC_MD5( bytes, len, result );
+    CC_MD5( bytes, (unsigned int)len, result );
     return [NSString stringWithFormat:
             @"%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
             result[0], result[1], result[2], result[3], 
@@ -163,21 +163,21 @@ void ExtractKeyAndIVFromPassphrase(const char *pass,
 
     memcpy(tmpStr, pass, passLen);
     memcpy(tmpStr + passLen, &salt[0], SaltLen);
-    CC_MD5(tmpStr, passLen + SaltLen, lastKey);
+    CC_MD5(tmpStr, (unsigned int)passLen + SaltLen, lastKey);
     memcpy(key, lastKey, kCCKeySizeAES128);   
     //NSLog(@"key1: %@", md5(tmpStr, passLen + SaltLen));
           
     memcpy(tmpStr, key, kCCKeySizeAES128);
     memcpy(tmpStr + kCCKeySizeAES128, pass, passLen);
     memcpy(tmpStr + kCCKeySizeAES128 + passLen, &salt[0], SaltLen);
-    CC_MD5(tmpStr, kCCKeySizeAES128 + passLen + SaltLen, lastKey);
+    CC_MD5(tmpStr, kCCKeySizeAES128 + (unsigned int)passLen + SaltLen, lastKey);
     memcpy(key + kCCKeySizeAES128, lastKey, kCCKeySizeAES128);   
     //NSLog(@"key2: %@", md5(tmpStr, kCCKeySizeAES128 + passLen + SaltLen));
     
     memcpy(tmpStr, lastKey, kCCKeySizeAES128);
     memcpy(tmpStr + kCCKeySizeAES128, pass, passLen);
     memcpy(tmpStr + kCCKeySizeAES128 + passLen, &salt[0], SaltLen);
-    CC_MD5(tmpStr, kCCKeySizeAES128 + passLen + SaltLen, iv);
+    CC_MD5(tmpStr, kCCKeySizeAES128 + (unsigned int)passLen + SaltLen, iv);
     //NSLog(@"iv: %@", md5(tmpStr, kCCKeySizeAES128 + passLen + SaltLen));
 }
 


### PR DESCRIPTION
Remaining 7 warnings should be targeted seperately

In the CoreData model there are some reserved word used as property name. In the current state of the project I was not able to create a new model version to start a migration. This should be done in a separate pull request.

The meanwhile deprecated `AlertView` is tightly bound into `SettingsController`. The change to `AlertViewController`could be done when migrating the project to use of storyboards ;)