### PR TITLE
add pods generated files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,10 @@ xcuserdata
 
 ####
 # Custom ignores for MobileOrg Project
+
 vendor-libs
 Classes/Sync/Dropbox/DropboxKeys.h
 DropBoxKeys.xcconfig
+
+MobileOrg.xcworkspace
+Pods


### PR DESCRIPTION
I've added these folders to `.gitignore` as they are making git directory dirty. But you might want to commit them allover. Not sure about your policy. 