### PR TITLE
Reflecting changes to website

### DIFF
--- a/Classes/Settings/SettingsController.swift
+++ b/Classes/Settings/SettingsController.swift
@@ -99,19 +99,19 @@ class SettingsController: UITableViewController {
   }
   
   @IBAction func showCredits(_ sender: UIButton) {
-    if let url = URL(string: "https://mobileorg.github.io#credits") {
+    if let url = URL(string: "https://mobileorg.github.io/credits") {
       UIApplication.shared.openURL(url)
     }
   }
 
   @IBAction func showDocumentation(_ sender: UIButton) {
-    if let url = URL(string: "https://mobileorg.github.io#documentation") {
+    if let url = URL(string: "https://mobileorg.github.io/documentation") {
       UIApplication.shared.openURL(url)
     }
   }
 
   @IBAction func showLicense(_ sender: Any) {
-    if let url = URL(string: "https://mobileorg.github.io#license") {
+    if let url = URL(string: "https://mobileorg.github.io/license") {
       UIApplication.shared.openURL(url)
     }
   }


### PR DESCRIPTION
Although old links still work, direct links to pages would allow us to
change the home page in the future.
