### PR TITLE
Encryption password field is initialised

### DIFF
--- a/Classes/Settings/SettingsController.swift
+++ b/Classes/Settings/SettingsController.swift
@@ -69,6 +69,11 @@ class SettingsController: UITableViewController {
     } else {
       self.lastSyncLabel.text = "Not yet synced"
     }
+
+    if let password = Settings.instance().encryptionPassword {
+      self.encryptionTextField.text = password
+    }
+
     self.tableView.reloadData()
     self.tableView.setNeedsDisplay()
   }


### PR DESCRIPTION
once settings view is loaded

Could fix #189 