### PR TITLE
Remove table view detail/disclosure indicators

### DIFF
--- a/Classes/Capture/NoteListController.m
+++ b/Classes/Capture/NoteListController.m
@@ -213,8 +213,6 @@
 
         cell.detailTextLabel.text = createdAtStr;
 
-        cell.accessoryType = UIButtonTypeDetailDisclosure;
-
         return cell;
 
     } else {
@@ -236,8 +234,6 @@
         [formatter setDateFormat:@"YYYY-MM-dd EEE HH:mm"];
         cell.detailTextLabel.text = [formatter stringFromDate:[note createdAt]];
         [formatter release];
-
-        cell.accessoryType = UIButtonTypeDetailDisclosure;
 
         return cell;
     }

--- a/Classes/Utilities/TableUtils.m
+++ b/Classes/Utilities/TableUtils.m
@@ -193,7 +193,7 @@ void SetupOutlineCellForNode(UITableViewCell *cell, Node *node, UITableView *tab
         [cell.contentView addSubview:bodySummaryLabel];
     }
 
-    [cell setAccessoryType:UITableViewCellAccessoryDetailDisclosureButton];
+    [cell setAccessoryType:UITableViewCellAccessoryDisclosureIndicator];
 }
 
 void PopulateOutlineCellForNode(UITableViewCell *cell, Node *node) {


### PR DESCRIPTION
- removes the info button from the capture and outline list
- removes the chevron from the capture list, too (consistent with displaying a note in e.g. Notes.app)

Closes #217.