### PR TITLE
[iOS 12.2 beta] Fixed a crash on Alert Controller presentation

### DIFF
--- a/Classes/Sync/SyncManager.m
+++ b/Classes/Sync/SyncManager.m
@@ -846,25 +846,21 @@ static SyncManager *gInstance = NULL;
 }
 
 
-  - (void) showAlert:(NSString*)alertTitle withText:(NSString*)alertMessage {
-
-  UIAlertController *alertController = [UIAlertController alertControllerWithTitle:alertTitle message:alertMessage preferredStyle:UIAlertControllerStyleAlert];
-  UIAlertAction* ok = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
-  [alertController addAction:ok];
-
-
-  id rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
-  if([rootViewController isKindOfClass:[UINavigationController class]])
-    {
-    rootViewController = ((UINavigationController *)rootViewController).viewControllers.firstObject;
+- (void)showAlert:(NSString*)alertTitle withText:(NSString*)alertMessage {
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:alertTitle message:alertMessage preferredStyle:UIAlertControllerStyleAlert];
+    UIAlertAction* ok = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
+    [alertController addAction:ok];
+    
+    id rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
+    if ([rootViewController isKindOfClass:[UINavigationController class]]) {
+        rootViewController = ((UINavigationController *)rootViewController).viewControllers.firstObject;
     }
-  if([rootViewController isKindOfClass:[UITabBarController class]])
-    {
-    rootViewController = ((UITabBarController *)rootViewController).selectedViewController;
+    if ([rootViewController isKindOfClass:[UITabBarController class]]) {
+        rootViewController = ((UITabBarController *)rootViewController).selectedViewController;
     }
-  [rootViewController presentViewController:alertController animated:YES completion:nil];
-
-
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [rootViewController presentViewController:alertController animated:YES completion:nil];
+    });
 }
 
 - (void)dealloc {


### PR DESCRIPTION
There is a crash due to an issue with the alert controller presentation from the non-main thread. This simple patch fixes it.

P.S. I changed the formatting of the function, but the only real change is `dispatch_async(dispatch_get_main_queue()` around the `[rootViewController presentViewController:animated:completion:]`.