### PR TITLE
Fix for an issue with emojis within file names

### DIFF
--- a/Classes/DataModel/Node.h
+++ b/Classes/DataModel/Node.h
@@ -22,6 +22,8 @@
 
 #import <CoreData/CoreData.h>
 
+FOUNDATION_EXPORT NSString *const kUnixFileLinkRegex;
+
 @class LocalEditAction;
 
 @interface Node :  NSManagedObject

--- a/Classes/DataModel/Node.m
+++ b/Classes/DataModel/Node.m
@@ -45,7 +45,7 @@
 @dynamic notes;
 @dynamic children;
 
-static NSString *kUnixFileLinkRegex = @"\\[\\[file:(.*\\.(?:org|txt))\\]\\[(.*)\\]\\]";
+NSString *const kUnixFileLinkRegex = @"\\[\\[file:(.*\\.(?:org|txt))\\]\\[(.*)\\]\\]";
 
 
 - (NSComparisonResult)sequenceIndexCompare:(Node*)obj

--- a/Classes/Extensions/String+RegexSplitter.swift
+++ b/Classes/Extensions/String+RegexSplitter.swift
@@ -66,8 +66,8 @@ public extension NSString {
                 break;
             }
 
-          let begin = swiftString.index(swiftString.startIndex, offsetBy: range.location)
-          let end = swiftString.index(swiftString.startIndex, offsetBy: range.location+range.length)
+          let begin = swiftString.utf16.index(swiftString.startIndex, offsetBy: range.location)
+          let end = swiftString.utf16.index(swiftString.startIndex, offsetBy: range.location+range.length)
           result.append(String(swiftString[begin..<end]))
         }
       }

--- a/MobileOrgTests/String+RegexTests.swift
+++ b/MobileOrgTests/String+RegexTests.swift
@@ -75,6 +75,26 @@ class String_RegexTests: XCTestCase {
     XCTAssertEqual(output, test)
   }
 
+    // https://github.com/MobileOrg/mobileorg/issues/220
+    func testCaptureComponentsMatchedByForFilesWithEmojisInFileNames() {
+        let filename = "/internal/📝journal📝.org"
+        let orgURLString = "[[file:\(filename)][\(filename)]]"
+        let input = orgURLString as NSString
+        let output = [orgURLString, filename, filename]
+        let test = input.captureComponentsMatchedBy(regex: kUnixFileLinkRegex)
+        XCTAssertEqual(output, test)
+    }
+
+    // https://github.com/MobileOrg/mobileorg/issues/220
+    func testCaptureComponentsMatchedByForFilesWithEmojiAsFilename() {
+        let filename = "🎯.org"
+        let orgURLString = "[[file:\(filename)][\(filename)]]"
+        let input = orgURLString as NSString
+        let output = [orgURLString, filename, filename]
+        let test = input.captureComponentsMatchedBy(regex: kUnixFileLinkRegex)
+        XCTAssertEqual(output, test)
+    }
+
   override func setUp() {
     super.setUp()
     // Put setup code here. This method is called before the invocation of each test method in the class.


### PR DESCRIPTION
Hello there,

This is the fix to resolve #220. The fix aligns `NSRange` expectations for UTF16 based strings with the real world. Check [this comment](https://github.com/MobileOrg/mobileorg/issues/220#issuecomment-542867540) for additional information.

Regards,
Artem